### PR TITLE
Encode unicode values before passing through to hashlib

### DIFF
--- a/src/optimizations/assetcache.py
+++ b/src/optimizations/assetcache.py
@@ -35,7 +35,7 @@ def freeze_dict(params):
             value = value,
         )
         for key, value in sorted((params).iteritems())
-    )).hexdigest()
+    ).encode('utf-8')).hexdigest()
 
 
 class Asset(object):


### PR DESCRIPTION
A file with a path containing accented characters caused the `hashlib.sha1()` call to fail as it doesn't expect unicode data. This change encodes the generated string into UTF-8 before it gets passed through.
