### PR TITLE
Improve compatibility with older versions of Django.

### DIFF
--- a/src/optimizations/stylesheetcache.py
+++ b/src/optimizations/stylesheetcache.py
@@ -5,7 +5,11 @@ from contextlib import closing
 import os.path
 import re
 import subprocess
-from django.utils.six.moves.urllib.parse import urlparse
+
+try:
+    from django.utils.six.moves.urllib.parse import urlparse
+except ImportError:
+    from six.moves.urllib.parse import urlparse
 
 from django.conf import settings
 from django.core.files.base import ContentFile

--- a/src/optimizations/templatetags/assets.py
+++ b/src/optimizations/templatetags/assets.py
@@ -4,7 +4,11 @@ from __future__ import unicode_literals
 from django import template
 from django.utils.html import escape
 from django.utils import six
-from django.utils.six.moves.urllib.parse import urlparse
+
+try:
+    from django.utils.six.moves.urllib.parse import urlparse
+except ImportError:
+    from six.moves.urllib.parse import urlparse
 
 from optimizations.assetcache import StaticAsset, default_asset_cache, AdaptiveAsset
 from optimizations.thumbnailcache import default_thumbnail_cache, PROPORTIONAL, ThumbnailError


### PR DESCRIPTION
Older versions of Django, notably 1.5.x don't have the same version of six as later versions leading to errors when attempting to use newer versions of django-optimizations.  This pull request falls back to the system installed version of six if the import from Django's version fails.
